### PR TITLE
only scan files with a .css extension

### DIFF
--- a/lib/cc/engine/csslint.rb
+++ b/lib/cc/engine/csslint.rb
@@ -55,7 +55,7 @@ module CC
       end
 
       def files
-        Dir.glob("**/*css")
+        Dir.glob("**/*.css")
       end
     end
   end


### PR DESCRIPTION
I was noticing .scss being scanned, which isn't relevant because it's much broader syntax.

/cc https://github.com/ivantsepp/codeclimate-scss-lint