### PR TITLE
Don't report all errors on each file analyzed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/lib/cc/engine/csslint.rb
+++ b/lib/cc/engine/csslint.rb
@@ -14,23 +14,27 @@ module CC
         Dir.chdir(@directory) do
           results.xpath('//file').each do |file|
             path = file['name'].sub(/\A#{@directory}\//, '')
-            file.xpath('//error').each do |lint|
+            file.children.each do |node|
+              next unless node.name == "error"
+
+              lint = node.attributes
+
               issue = {
                 type: "issue",
-                check_name: lint["source"],
-                description: lint["message"],
+                check_name: lint["source"].value,
+                description: lint["message"].value,
                 categories: ["Style"],
                 remediation_points: 500,
                 location: {
                   path: path,
                   positions: {
                     begin: {
-                      line: lint["line"].to_i,
-                      column: lint["column"].to_i
+                      line: lint["line"].value.to_i,
+                      column: lint["column"].value.to_i
                     },
                     end: {
-                      line: lint["line"].to_i,
-                      column: lint["column"].to_i
+                      line: lint["line"].value.to_i,
+                      column: lint["column"].value.to_i
                     }
                   }
                 }

--- a/spec/cc/engine/csslint_spec.rb
+++ b/spec/cc/engine/csslint_spec.rb
@@ -22,6 +22,12 @@ module CC
           expect{ lint.run }.to_not output.to_stdout
         end
 
+        it "only reports issues in the file where they're present" do
+          create_source_file('bad.css', id_selector_content)
+          create_source_file('good.css', '.foo { margin: 0 }')
+          expect{ lint.run }.not_to output(/good\.css/).to_stdout
+        end
+
         describe "with exclude_paths" do
           let(:engine_config) { {"exclude_paths" => %w(excluded.css)} }
 


### PR DESCRIPTION
It's likely the original developer assumed that the pattern given to Node#xpath
is treated relative to the node on which it's called. That doesn't seem to
be the case.

The XPath "//error" finds ALL error nodes across the entire document, even when
invoked as file.xpath("//error"). This causes them all to be reported on every
file analyzed. Besides being extremely non-sensical, this can also be a
performance nightmare.

To correct this, we instead use Node#children to get only the currently
processing file's errors. This required replacing some hash accesses with
methods and the chaining of #value on attributes.

/cc @codeclimate/review