### PR TITLE
Raise default remediation, categorize checks

### DIFF
--- a/lib/cc/engine/csslint.rb
+++ b/lib/cc/engine/csslint.rb
@@ -4,6 +4,8 @@ require 'json'
 module CC
   module Engine
     class CSSlint
+      autoload :CheckDetails, "cc/engine/csslint/check_details"
+
       def initialize(directory: , io: , engine_config: )
         @directory = directory
         @engine_config = engine_config
@@ -18,13 +20,15 @@ module CC
               next unless node.name == "error"
 
               lint = node.attributes
+              check_name = lint["source"].value
+              check_details = CheckDetails.fetch(check_name)
 
               issue = {
                 type: "issue",
-                check_name: lint["source"].value,
+                check_name: check_name,
                 description: lint["message"].value,
-                categories: ["Style"],
-                remediation_points: 500,
+                categories: check_details.categories,
+                remediation_points: check_details.remediation_points,
                 location: {
                   path: path,
                   positions: {

--- a/lib/cc/engine/csslint/check_details.rb
+++ b/lib/cc/engine/csslint/check_details.rb
@@ -1,0 +1,55 @@
+module CC
+  module Engine
+    class CSSlint
+      # https://github.com/CSSLint/csslint/wiki/Rules
+      class CheckDetails
+        DEFAULT_CATEGORY = "Style".freeze
+        DEFAULT_REMEDIATION_POINTS = 50_000.freeze
+
+        attr_reader :categories, :remediation_points
+
+        def self.all
+          @all ||= {
+            "net.csslint.Adjoiningclasses" => new(categories: "Compatability"),
+            "net.csslint.Boxmodel" => new(categories: "Bug Risk"),
+            "net.csslint.Boxsizing" => new(categories: "Compatability"),
+            "net.csslint.Bulletprooffontface" => new(categories: "Compatability"),
+            "net.csslint.Compatiblevendorprefixes" => new(categories: "Compatability"),
+            "net.csslint.Displaypropertygrouping" => new(categories: "Bug Risk"),
+            "net.csslint.Duplicatebackgroundimages" => new(categories: "Bug Risk"),
+            "net.csslint.Duplicateproperties" => new(categories: "Bug Risk"),
+            "net.csslint.Emptyrules" => new(categories: "Bug Risk"),
+            "net.csslint.Fallbackcolors" => new(categories: "Compatability"),
+            "net.csslint.Fontfaces" => new(categories: "Bug Risk"),
+            "net.csslint.Gradients" => new(categories: "Compatability"),
+            "net.csslint.Import" => new(categories: "Bug Risk"),
+            "net.csslint.Knownproperties" => new(categories: "Bug Risk"),
+            "net.csslint.Overqualifiedelements" => new(categories: "Bug Risk"),
+            "net.csslint.Regexselectors" => new(categories: "Bug Risk"),
+            "net.csslint.Shorthand" => new(categories: "Bug Risk"),
+            "net.csslint.Starpropertyhack" => new(categories: "Compatability"),
+            "net.csslint.Textindent" => new(categories: "Compatability"),
+            "net.csslint.Underscorepropertyhack" => new(categories: "Compatability"),
+            "net.csslint.Uniqueheadings" => new(categories: "Duplication"),
+            "net.csslint.Universalselector" => new(categories: "Bug Risk"),
+            "net.csslint.Unqualifiedattributes" => new(categories: "Bug Risk"),
+            "net.csslint.Vendorprefix" => new(categories: "Compatability"),
+            "net.csslint.Zerounits" => new(categories: "Bug Risk"),
+          }
+        end
+
+        def self.fetch(check_name)
+          all.fetch(check_name) { new }
+        end
+
+        def initialize(
+          categories: DEFAULT_CATEGORY,
+          remediation_points: DEFAULT_REMEDIATION_POINTS
+        )
+          @categories = Array(categories)
+          @remediation_points = remediation_points
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/engine/csslint/check_details.rb
+++ b/lib/cc/engine/csslint/check_details.rb
@@ -1,45 +1,43 @@
 module CC
   module Engine
     class CSSlint
-      # https://github.com/CSSLint/csslint/wiki/Rules
       class CheckDetails
+        ALL_RULES = {
+          # https://github.com/CSSLint/csslint/wiki/Rules
+          "net.csslint.Adjoiningclasses" => { categories: "Compatability" },
+          "net.csslint.Boxmodel" => { categories: "Bug Risk" },
+          "net.csslint.Boxsizing" => { categories: "Compatability" },
+          "net.csslint.Bulletprooffontface" => { categories: "Compatability" },
+          "net.csslint.Compatiblevendorprefixes" => { categories: "Compatability" },
+          "net.csslint.Displaypropertygrouping" => { categories: "Bug Risk" },
+          "net.csslint.Duplicatebackgroundimages" => { categories: "Bug Risk" },
+          "net.csslint.Duplicateproperties" => { categories: "Bug Risk" },
+          "net.csslint.Emptyrules" => { categories: "Bug Risk" },
+          "net.csslint.Fallbackcolors" => { categories: "Compatability" },
+          "net.csslint.Fontfaces" => { categories: "Bug Risk" },
+          "net.csslint.Gradients" => { categories: "Compatability" },
+          "net.csslint.Import" => { categories: "Bug Risk" },
+          "net.csslint.Knownproperties" => { categories: "Bug Risk" },
+          "net.csslint.Overqualifiedelements" => { categories: "Bug Risk" },
+          "net.csslint.Regexselectors" => { categories: "Bug Risk" },
+          "net.csslint.Shorthand" => { categories: "Bug Risk" },
+          "net.csslint.Starpropertyhack" => { categories: "Compatability" },
+          "net.csslint.Textindent" => { categories: "Compatability" },
+          "net.csslint.Underscorepropertyhack" => { categories: "Compatability" },
+          "net.csslint.Uniqueheadings" => { categories: "Duplication" },
+          "net.csslint.Universalselector" => { categories: "Bug Risk" },
+          "net.csslint.Unqualifiedattributes" => { categories: "Bug Risk" },
+          "net.csslint.Vendorprefix" => { categories: "Compatability" },
+          "net.csslint.Zerounits" => { categories: "Bug Risk" },
+        }.freeze
+
         DEFAULT_CATEGORY = "Style".freeze
         DEFAULT_REMEDIATION_POINTS = 50_000.freeze
 
         attr_reader :categories, :remediation_points
 
-        def self.all
-          @all ||= {
-            "net.csslint.Adjoiningclasses" => new(categories: "Compatability"),
-            "net.csslint.Boxmodel" => new(categories: "Bug Risk"),
-            "net.csslint.Boxsizing" => new(categories: "Compatability"),
-            "net.csslint.Bulletprooffontface" => new(categories: "Compatability"),
-            "net.csslint.Compatiblevendorprefixes" => new(categories: "Compatability"),
-            "net.csslint.Displaypropertygrouping" => new(categories: "Bug Risk"),
-            "net.csslint.Duplicatebackgroundimages" => new(categories: "Bug Risk"),
-            "net.csslint.Duplicateproperties" => new(categories: "Bug Risk"),
-            "net.csslint.Emptyrules" => new(categories: "Bug Risk"),
-            "net.csslint.Fallbackcolors" => new(categories: "Compatability"),
-            "net.csslint.Fontfaces" => new(categories: "Bug Risk"),
-            "net.csslint.Gradients" => new(categories: "Compatability"),
-            "net.csslint.Import" => new(categories: "Bug Risk"),
-            "net.csslint.Knownproperties" => new(categories: "Bug Risk"),
-            "net.csslint.Overqualifiedelements" => new(categories: "Bug Risk"),
-            "net.csslint.Regexselectors" => new(categories: "Bug Risk"),
-            "net.csslint.Shorthand" => new(categories: "Bug Risk"),
-            "net.csslint.Starpropertyhack" => new(categories: "Compatability"),
-            "net.csslint.Textindent" => new(categories: "Compatability"),
-            "net.csslint.Underscorepropertyhack" => new(categories: "Compatability"),
-            "net.csslint.Uniqueheadings" => new(categories: "Duplication"),
-            "net.csslint.Universalselector" => new(categories: "Bug Risk"),
-            "net.csslint.Unqualifiedattributes" => new(categories: "Bug Risk"),
-            "net.csslint.Vendorprefix" => new(categories: "Compatability"),
-            "net.csslint.Zerounits" => new(categories: "Bug Risk"),
-          }
-        end
-
         def self.fetch(check_name)
-          all.fetch(check_name) { new }
+          new(ALL_RULES.fetch(check_name, {}))
         end
 
         def initialize(

--- a/spec/cc/engine/csslint/check_details_spec.rb
+++ b/spec/cc/engine/csslint/check_details_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+class CC::Engine::CSSlint
+  describe CheckDetails do
+    describe ".fetch" do
+      it "returns details for customized checks" do
+        details = CheckDetails.fetch("net.csslint.Import")
+
+        expect(details.categories).to eq ["Bug Risk"]
+        expect(details.remediation_points).to eq 50_000
+      end
+
+      it "returns defaults for unknown checks" do
+        details = CheckDetails.fetch("made-up")
+
+        expect(details.categories).to eq ["Style"]
+        expect(details.remediation_points).to eq 50_000
+      end
+    end
+  end
+end

--- a/spec/cc/engine/csslint_spec.rb
+++ b/spec/cc/engine/csslint_spec.rb
@@ -1,5 +1,4 @@
-require 'cc/engine/csslint'
-require 'tmpdir'
+require "spec_helper"
 
 module CC
   module Engine

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require "cc/engine/csslint"
+require "tmpdir"


### PR DESCRIPTION
Default remediation was at an abysmal 500, upped it to the "trivial" baseline
for now and built a small class allowing us to easily override later.

Categorized checks loosely based on the CSSLint wiki[1]. The most obvious
departure was categorizing Performance rules as Bug Risk checks.

I chose keyword arguments in CheckDetails so we can easily create an override
object for one, the other, or both of categories and remediation points.

1: https://github.com/CSSLint/csslint/wiki/Rules

/cc @codeclimate/review