### PR TITLE
Bump csslint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apk --update add nodejs git ruby ruby-dev ruby-bundler less ruby-nokogiri bu
     bundle install -j 4 && \
     apk del build-base && rm -fr /usr/share/ri
 
-RUN npm install -g codeclimate/csslint.git#43d315c2
+ENV CSSLINT_SHA=0e7aeadd02f5babca5152993374043f9f736a116
+RUN npm install -g codeclimate/csslint.git#$CSSLINT_COMMIT
 
 RUN adduser -u 9000 -D app
 USER app


### PR DESCRIPTION
This commit fixes the checkstyle-xml formatter to include an identifier
attribute on all errors. File read errors were previously missed and caused a
NoMethodError in the engine when an identifier attribute was used on these
errors.

The commit sha was also extracted to a variable in the Dockerfile and added as
a full commit sha. This makes for easier editing (git log or the GitHub UI most
often gives you full shas) and should keep the diff clearer that only the sha
was changed.

/cc @codeclimate/review

I left the "compare link" out of this commit because it would just be a link to
that commit which is information already present in the diff itself.