### PR TITLE
Better error handling when parsing CSSLint XML output

### DIFF
--- a/lib/cc/engine/csslint.rb
+++ b/lib/cc/engine/csslint.rb
@@ -3,6 +3,7 @@ require 'json'
 
 module CC
   module Engine
+    MissingAttributesError = Class.new(StandardError)
     class CSSlint
       autoload :CheckDetails, "cc/engine/csslint/check_details"
 
@@ -85,8 +86,6 @@ module CC
           build_files_with_exclusions(@engine_config["exclude_paths"] || [])
         end
       end
-    end
-    class MissingAttributesError < StandardError
     end
   end
 end

--- a/lib/cc/engine/csslint.rb
+++ b/lib/cc/engine/csslint.rb
@@ -30,7 +30,8 @@ module CC
       def create_issue(node, path)
         check_name = node.attributes.fetch("identifier").value
         check_details = CheckDetails.fetch(check_name)
-        return {
+        
+        {
           type: "issue",
           check_name: check_name,
           description: node.attributes.fetch("message").value,

--- a/lib/cc/engine/csslint.rb
+++ b/lib/cc/engine/csslint.rb
@@ -19,32 +19,36 @@ module CC
             file.children.each do |node|
               next unless node.name == "error"
 
-              lint = node.attributes
-              check_name = lint["identifier"].value
-              check_details = CheckDetails.fetch(check_name)
+              begin
+                lint = node.attributes
+                check_name = lint["identifier"].value
+                check_details = CheckDetails.fetch(check_name)
 
-              issue = {
-                type: "issue",
-                check_name: check_name,
-                description: lint["message"].value,
-                categories: check_details.categories,
-                remediation_points: check_details.remediation_points,
-                location: {
-                  path: path,
-                  positions: {
-                    begin: {
-                      line: lint["line"].value.to_i,
-                      column: lint["column"].value.to_i
-                    },
-                    end: {
-                      line: lint["line"].value.to_i,
-                      column: lint["column"].value.to_i
+                issue = {
+                  type: "issue",
+                  check_name: check_name,
+                  description: lint["message"].value,
+                  categories: check_details.categories,
+                  remediation_points: check_details.remediation_points,
+                  location: {
+                    path: path,
+                    positions: {
+                      begin: {
+                        line: lint["line"].value.to_i,
+                        column: lint["column"].value.to_i
+                      },
+                      end: {
+                        line: lint["line"].value.to_i,
+                        column: lint["column"].value.to_i
+                      }
                     }
                   }
                 }
-              }
 
-              puts("#{issue.to_json}\0")
+                puts("#{issue.to_json}\0")
+              rescue
+                STDERR.puts("CodeClimate unsupported csslint issue: #{node}")
+              end
             end
           end
         end

--- a/lib/cc/engine/csslint.rb
+++ b/lib/cc/engine/csslint.rb
@@ -31,7 +31,7 @@ module CC
       def create_issue(node, path)
         check_name = node.attributes.fetch("identifier").value
         check_details = CheckDetails.fetch(check_name)
-        
+
         {
           type: "issue",
           check_name: check_name,

--- a/lib/cc/engine/csslint.rb
+++ b/lib/cc/engine/csslint.rb
@@ -28,32 +28,30 @@ module CC
       private
 
       def create_issue(node, path)
-        begin
-          check_name = node.attributes.fetch("identifier").value
-          check_details = CheckDetails.fetch(check_name)
-          return {
-            type: "issue",
-            check_name: check_name,
-            description: node.attributes.fetch("message").value,
-            categories: check_details.categories,
-            remediation_points: check_details.remediation_points,
-            location: {
-              path: path,
-              positions: {
-                begin: {
-                  line: node.attributes.fetch("line").value.to_i,
-                  column: node.attributes.fetch("column").value.to_i
-                },
-                end: {
-                  line: node.attributes.fetch("line").value.to_i,
-                  column: node.attributes.fetch("column").value.to_i
-                }
+        check_name = node.attributes.fetch("identifier").value
+        check_details = CheckDetails.fetch(check_name)
+        return {
+          type: "issue",
+          check_name: check_name,
+          description: node.attributes.fetch("message").value,
+          categories: check_details.categories,
+          remediation_points: check_details.remediation_points,
+          location: {
+            path: path,
+            positions: {
+              begin: {
+                line: node.attributes.fetch("line").value.to_i,
+                column: node.attributes.fetch("column").value.to_i
+              },
+              end: {
+                line: node.attributes.fetch("line").value.to_i,
+                column: node.attributes.fetch("column").value.to_i
               }
             }
           }
-        rescue KeyError => e
-          raise MissingAttributesError, "#{e.message} on XML '#{node}' when analyzing file '#{path}'"
-        end
+        }
+      rescue KeyError => e
+        raise MissingAttributesError, "#{e.message} on XML '#{node}' when analyzing file '#{path}'"
       end
 
       def results

--- a/spec/cc/engine/csslint_spec.rb
+++ b/spec/cc/engine/csslint_spec.rb
@@ -16,6 +16,11 @@ module CC
           expect{ lint.run }.to output(/Don't use IDs in selectors./).to_stdout
         end
 
+        it 'fails on malformed file' do
+          create_source_file('foo.css', '')
+          expect{ lint.run }.to raise_error(MissingAttributesError)
+        end
+
         it "doesn't analyze *.scss files" do
           create_source_file('foo.scss', id_selector_content)
           expect{ lint.run }.to_not output.to_stdout

--- a/spec/cc/engine/csslint_spec.rb
+++ b/spec/cc/engine/csslint_spec.rb
@@ -17,7 +17,7 @@ module CC
         end
 
         it 'fails on malformed file' do
-          create_source_file('foo.css', '')
+          create_source_file('foo.css', '�6�')
           expect{ lint.run }.to raise_error(MissingAttributesError)
         end
 


### PR DESCRIPTION
This is the simplest solution I could come up with to avoid engine failures due to weird or malformed csslint error nodes. (see #25)

I tried to write a test to cover this change but I wasn't able to come up with a piece of CSS which caused such malformed error to be generated by csslint.

Thoughts?