### PR TITLE
Minor fixes

### DIFF
--- a/lib/cc/engine/csslint.rb
+++ b/lib/cc/engine/csslint.rb
@@ -62,7 +62,7 @@ module CC
       end
 
       def csslint_xml
-        `csslint --format=checkstyle-xml #{files_to_inspect.join(" ")}`
+        `csslint --format=checkstyle-xml #{files_to_inspect.shelljoin}`
       end
 
       def files_to_inspect

--- a/lib/cc/engine/csslint.rb
+++ b/lib/cc/engine/csslint.rb
@@ -61,30 +61,18 @@ module CC
         @results ||= Nokogiri::XML(csslint_xml)
       end
 
-      def build_files_with_exclusions(exclusions)
-        files = Dir.glob("**/*.css")
-        files.reject { |f| exclusions.include?(f) }
-      end
-
-      def build_files_with_inclusions(inclusions)
-        inclusions.map do |include_path|
-          if include_path =~ %r{/$}
-            Dir.glob("#{include_path}/**/*.css")
-          else
-            include_path if include_path =~ /\.css$/
-          end
-        end.flatten.compact
-      end
-
       def csslint_xml
         `csslint --format=checkstyle-xml #{files_to_inspect.join(" ")}`
       end
 
       def files_to_inspect
-        if @engine_config["include_paths"]
-          build_files_with_inclusions(@engine_config["include_paths"])
-        else
-          build_files_with_exclusions(@engine_config["exclude_paths"] || [])
+        include_paths = @engine_config["include_paths"] || ["./"]
+        include_paths.each_with_object([]) do |path, out|
+          if path.end_with?("/")
+            out.concat(Dir.glob("#{path}**/*.css"))
+          elsif path.end_with?(".css")
+            out << path
+          end
         end
       end
     end

--- a/spec/cc/engine/csslint_spec.rb
+++ b/spec/cc/engine/csslint_spec.rb
@@ -32,20 +32,6 @@ module CC
           expect{ lint.run }.not_to output(/good\.css/).to_stdout
         end
 
-        describe "with exclude_paths" do
-          let(:engine_config) { {"exclude_paths" => %w(excluded.css)} }
-
-          before do
-            create_source_file("not_excluded.css", "p { margin: 5px }")
-            create_source_file("excluded.css", id_selector_content)
-          end
-
-          it "excludes all matching paths" do
-            expect{ lint.run }.not_to \
-              output(/Don't use IDs in selectors./).to_stdout
-          end
-        end
-
         describe "with include_paths" do
           let(:engine_config) {
             {"include_paths" => %w(included.css included_dir/ config.yml)}
@@ -79,6 +65,7 @@ module CC
           end
 
           it "shouldn't call a top-level Dir.glob ever" do
+            allow(Dir).to receive(:glob).and_call_original
             expect(Dir).not_to receive(:glob).with("**/*.css")
             expect{ lint.run }.to \
               output(/Don't use IDs in selectors./).to_stdout


### PR DESCRIPTION
- Remove support for `exclude_paths`

  Refactor `#files_to_inspect` a little in the course of doing so.

- Use `shelljoin`

  Ensures any file arguments with spaces are correctly handled.