### PR TITLE
require shellwords

### DIFF
--- a/lib/cc/engine/csslint.rb
+++ b/lib/cc/engine/csslint.rb
@@ -1,5 +1,6 @@
-require 'nokogiri'
-require 'json'
+require "json"
+require "nokogiri"
+require "shellwords"
 
 module CC
   module Engine


### PR DESCRIPTION
Needs to be explicitly required.

cc @codeclimate/review