### PR TITLE
Don't crash on parse errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ image:
 	docker build -t codeclimate/codeclimate-csslint .
 
 test: image
-	docker run --rm codeclimate/codeclimate-csslint rake
+	docker run --rm codeclimate/codeclimate-csslint rspec $(RSPEC_ARGS)

--- a/lib/cc/engine/csslint.rb
+++ b/lib/cc/engine/csslint.rb
@@ -22,7 +22,7 @@ module CC
             file.children.each do |node|
               next unless node.name == "error"
               issue =
-                if node.attributes.has_key?("identifier")
+                if node.attributes.key?("identifier")
                   create_issue(node, path)
                 else
                   create_error(node, path)
@@ -35,6 +35,7 @@ module CC
 
       private
 
+      # rubocop:disable Metrics/MethodLength
       def create_issue(node, path)
         check_name = node.attributes.fetch("identifier").value
         check_details = CheckDetails.fetch(check_name)
@@ -62,11 +63,13 @@ module CC
       rescue KeyError => ex
         raise MissingAttributesError, "#{ex.message} on XML '#{node}' when analyzing file '#{path}'"
       end
+      # rubocop:enable Metrics/MethodLength
 
+      # rubocop:disable Metrics/MethodLength
       def create_error(node, path)
         {
           type: "issue",
-          check_name: "parse_error",
+          check_name: "parse-error",
           description: node.attributes.fetch("message").value,
           categories: ["Bug Risk"],
           remediation_points: 5_000,
@@ -87,6 +90,7 @@ module CC
       rescue KeyError => ex
         raise MissingAttributesError, "#{ex.message} on XML error '#{node}' when analyzing file '#{path}'"
       end
+      # rubocop:enable Metrics/MethodLength
 
       def results
         @results ||= Nokogiri::XML(csslint_xml)

--- a/lib/cc/engine/csslint/check_details.rb
+++ b/lib/cc/engine/csslint/check_details.rb
@@ -19,6 +19,7 @@ module CC
           "import" => { categories: "Bug Risk" },
           "known-properties" => { categories: "Bug Risk" },
           "overqualified-elements" => { categories: "Bug Risk" },
+	  "parse-error" => { categories: "Bug Risk" },
           "regex-selectors" => { categories: "Bug Risk" },
           "shorthand" => { categories: "Bug Risk" },
           "star-property-hack" => { categories: "Compatibility" },

--- a/lib/cc/engine/csslint/check_details.rb
+++ b/lib/cc/engine/csslint/check_details.rb
@@ -19,7 +19,7 @@ module CC
           "import" => { categories: "Bug Risk" },
           "known-properties" => { categories: "Bug Risk" },
           "overqualified-elements" => { categories: "Bug Risk" },
-	  "parse-error" => { categories: "Bug Risk" },
+          "parse-error" => { categories: "Bug Risk" },
           "regex-selectors" => { categories: "Bug Risk" },
           "shorthand" => { categories: "Bug Risk" },
           "star-property-hack" => { categories: "Compatibility" },

--- a/spec/cc/engine/csslint_spec.rb
+++ b/spec/cc/engine/csslint_spec.rb
@@ -18,7 +18,7 @@ module CC
 
         it 'fails on malformed file' do
           create_source_file('foo.css', '�6�')
-          expect{ lint.run }.to raise_error(MissingAttributesError)
+          expect{ lint.run }.to output(/Unexpected token/).to_stdout
         end
 
         it "doesn't analyze *.scss files" do


### PR DESCRIPTION
Instead of crashing out when encountering a parse error, this will report
the issue as a parse error.

cc @codeclimate/review a bit different from other engines because we're not outputting to stderr, but this seems useful.