### PR TITLE
Update expectation of where the config is

### DIFF
--- a/lib/cc/engine/csslint.rb
+++ b/lib/cc/engine/csslint.rb
@@ -77,7 +77,7 @@ module CC
 
       def files_to_inspect
         include_paths = engine_config.fetch("include_paths", ["./"])
-        extensions = engine_config.fetch("extensions", DEFAULT_EXTENSIONS)
+        extensions = engine_config.fetch("config", {}).fetch("extensions", DEFAULT_EXTENSIONS)
         extensions_glob = extensions.join(",")
         include_paths.flat_map do |path|
           if path.end_with?("/")

--- a/spec/cc/engine/csslint_spec.rb
+++ b/spec/cc/engine/csslint_spec.rb
@@ -79,7 +79,9 @@ module CC
         describe "with custom extensions" do
           let(:engine_config) do
             {
-              "extensions" => %w(.fancycss)
+              "config" => {
+                "extensions" => %w(.fancycss)
+              }
             }
           end
 


### PR DESCRIPTION
We pass the top-level config for the engine, meaning that the extensions
and include_paths are in a `config` key.